### PR TITLE
クレジットカード情報チェックボタンを削除

### DIFF
--- a/Resource/template/credit.twig
+++ b/Resource/template/credit.twig
@@ -16,7 +16,6 @@
                     <!-- ここにエラーメッセージが表示される -->
                     <div id="card-errors" role="alert"></div>
                 </div>
-                <button id="stripe" class="ec-blockBtn--action">クレジットカード情報チェック</button>
                 {{ form_widget(form.stripe_token, {type: 'hidden'}) }}
             </div>
         </div>
@@ -57,22 +56,39 @@
                 }
             });
 
-            // submit時のリスナー
-            var button = document.getElementById('stripe');
-            button.addEventListener('click', function(event) {
-                event.preventDefault();
+            window.addEventListener("load", stripeCheckoutHandler, false);
 
-                // Stripeサーバにクレジットカード情報を送信してクレジットカードトークンを取得する
-                stripe.createToken(card).then(function(result) {
-                    if (result.error) {
-                        var errorElement = document.getElementById('card-errors');
-                        errorElement.textContent = result.error.message;
-                    } else {
-                        // クレジットカードトークンをサーバにsubmitする
-                        stripeTokenHandler(result.token);
+            function stripeCheckoutHandler(e) {
+                var selector = '#shopping-form > div > div.ec-orderRole__summary > div > div.ec-totalBox__btn > button';
+                var jsInitCheckTimer = setInterval(jsLoaded, 1000);
+                function jsLoaded() {
+                    if (document.querySelector(selector) != null) {
+                        clearInterval(jsInitCheckTimer);
                     }
-                });
-            });
+                    // submit時のリスナー
+                    var button = document.querySelector(selector);
+                    button.addEventListener('click', function(event) {
+                        event.preventDefault();
+
+                        // Stripeサーバにクレジットカード情報を送信してクレジットカードトークンを取得する
+                        stripe.createToken(card).then(function(result) {
+                            if (result.error) {
+                                var errorElement = document.getElementById('card-errors');
+                                errorElement.textContent = result.error.message;
+                                var overlay = document.querySelector('.bg-load-overlay');
+                                overlay.remove();
+                            } else {
+                                // クレジットカードトークンをサーバにsubmitする
+                                stripeTokenHandler(result.token);
+                                setTimeout(function() {
+                                    var form = document.getElementById('shopping-form');
+                                    form.submit();
+                                }, 1000);
+                            }
+                        });
+                    });
+                }
+            }
 
             function stripeTokenHandler(token) {
                 var form = document.getElementById('shopping-form');


### PR DESCRIPTION
- **クレジットカード情報チェックボタン** をクリックしなくても、 **注文を確認する** ボタンでトークンを取得できるよう修正
- **確認する** ボタンが表示されるのを待って、submit時のリスナーを設定しています